### PR TITLE
Added more error handling for missing key section in qemu.rst

### DIFF
--- a/source/qemu.rst
+++ b/source/qemu.rst
@@ -377,6 +377,21 @@ For example, if you see an error about key '1234ABCD', run::
 Note: In newer Debian versions, apt-key is deprecated, but this approach 
 still works for the Debian images provided above.
 
+If you get any error such as **'gpg not found, this operation requires gnupg or gnupg2'** be sure to run these commands::
+
+Download the ASCII-armored key::
+    
+    wget https://ftp-master.debian.org/keys/archive-key-12.asc -O /etc/apt/trusted.gpg.d/debian-ports.asc
+  
+Download a pre-converted .gpg version of the same key (already dearmored)::
+    
+    wget https://people.debian.org/~gio/archive-key-12.gpg -O /etc/apt/trusted.gpg.d/debian-ports.gpg
+  
+Then run as usual::
+    
+    apt update
+
+
 How to run QEMU with Debian-10 installer image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/qemu.rst
+++ b/source/qemu.rst
@@ -377,7 +377,7 @@ For example, if you see an error about key '1234ABCD', run::
 Note: In newer Debian versions, apt-key is deprecated, but this approach 
 still works for the Debian images provided above.
 
-If you get any error such as **'gpg not found, this operation requires gnupg or gnupg2'** be sure to run these commands::
+If you get any error such as **'gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation'** be sure to run these commands::
 
 Download the ASCII-armored key::
     


### PR DESCRIPTION
While working on patch for TDR for i82596 in QEMU, faced this issue installing packages for guest debian OS.

Basically when we try to update keys it gives error: 
`gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation` 

So added documentation to circumvent this error, as I had faced this during initial setup too.